### PR TITLE
Fetch database from application's db config

### DIFF
--- a/lib/active_record/connection_adapters/ghost_mysql2_adapter.rb
+++ b/lib/active_record/connection_adapters/ghost_mysql2_adapter.rb
@@ -39,6 +39,7 @@ module ActiveRecord
 
       def initialize(connection, logger, connection_options, config, dry_run: false)
         super(connection, logger, connection_options, config)
+        @database = config[:database]
         @dry_run = dry_run
       end
 
@@ -49,7 +50,7 @@ module ActiveRecord
         return if dry_run && should_skip_for_dry_run?(sql)
 
         if (table, query = parse_sql(sql))
-          GhostAdapter::Migrator.execute(table, query, dry_run)
+          GhostAdapter::Migrator.execute(table, query, database, dry_run)
         else
           super(sql, name)
         end
@@ -57,7 +58,7 @@ module ActiveRecord
 
       private
 
-      attr_reader :dry_run
+      attr_reader :database, :dry_run
 
       ALTER_TABLE_PATTERN = /\AALTER\s+TABLE\W*(?<table_name>\w+)\W*(?<query>.*)$/i.freeze
       QUERY_ALLOWABLE_CHARS = /[^0-9a-z_\s():'"{}]/i.freeze

--- a/lib/ghost_adapter/command.rb
+++ b/lib/ghost_adapter/command.rb
@@ -1,8 +1,9 @@
 module GhostAdapter
   class Command
-    def initialize(alter:, table:, dry_run: false)
+    def initialize(alter:, table:, database: nil, dry_run: false)
       @alter = alter
       @table = table
+      @database = GhostAdapter.config.database || database
       @dry_run = dry_run
       validate_args_and_config!
     end
@@ -20,12 +21,12 @@ module GhostAdapter
 
     EXECUTABLE = 'gh-ost'.freeze
 
-    attr_reader :alter, :table, :dry_run
+    attr_reader :alter, :database, :table, :dry_run
 
     def validate_args_and_config!
       raise ArgumentError, 'alter cannot be nil' if alter.nil?
       raise ArgumentError, 'table cannot be nil' if table.nil?
-      raise ArgumentError, 'database name missing in config' if database.nil?
+      raise ArgumentError, 'database cannot be nil' if database.nil?
     end
 
     def base_args
@@ -38,10 +39,6 @@ module GhostAdapter
 
     def execute_arg
       dry_run ? [] : ['--execute']
-    end
-
-    def database
-      GhostAdapter.config.database
     end
   end
 end

--- a/lib/ghost_adapter/migrator.rb
+++ b/lib/ghost_adapter/migrator.rb
@@ -8,8 +8,10 @@ module GhostAdapter
   end
 
   class Migrator
-    def self.execute(table, query, dry_run)
-      command = GhostAdapter::Command.new(alter: query, table: table, dry_run: dry_run)
+    def self.execute(table, query, database, dry_run)
+      command = GhostAdapter::Command.new(
+        alter: query, table: table, database: database, dry_run: dry_run
+      )
       Open3.popen2e(*command.to_a) do |_stdin, stdout_stderr, wait_thread|
         stdout_stderr.each_line do |line|
           puts "[gh-ost]:\t\t#{line}"


### PR DESCRIPTION
## Description

This makes it so a user doesn't _need_ to pass a database name into the ghost adapter config.  It's somewhat likely we can just fetch it from the db config.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines set by rubocop
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
