### PR TITLE
Fix the links for the README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 ![ghost](./doc/images/ghost.png)
 
-![gem version](https://img.shields.io/gem/v/ghost_adapter)
-![travis](https://img.shields.io/travis/com/wetransfer/ghost_adapter)
-![Hippocratic License](https://img.shields.io/badge/license-Hippocratic-green?link=https://github.com/WeTransfer/ghost_adapter/blob/main/LICENSE.md)
-![gh-ost version](https://img.shields.io/badge/gh--ost%20version-1.1.0-blue?link=https://github.com/github/gh-ost/releases/latest)
-![depfu](https://img.shields.io/depfu/wetransfer/ghost_adapter)
+[![Gem](https://img.shields.io/gem/v/ghost_adapter)](https://rubygems.org/gems/ghost_adapter)
+[![Build Status](https://travis-ci.com/WeTransfer/ghost_adapter.svg?branch=main)](https://travis-ci.com/WeTransfer/ghost_adapter)
+[![Hippocratic License](https://img.shields.io/badge/license-Hippocratic-green)](https://github.com/WeTransfer/ghost_adapter/blob/main/LICENSE.md)
+[![gh-ost version](https://img.shields.io/badge/gh--ost%20version-1.1.0-blue)](https://github.com/github/gh-ost/releases/latest)
 
 A tiny, _very configurable_ ActiveRecord adapter built for running [gh-ost](https://github.com/github/gh-ost) migrations. When not running migrations, it'll stay the heck out of the way.
 


### PR DESCRIPTION
## Description

Currently the README badges have accurate info, but useless links.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Viewed the README locally

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
