### PR TITLE
Fix bug where ENV config gets overwritten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
 
+## 0.1.3
+- Fix bug [#26](https://github.com/WeTransfer/ghost_adapter/issues/26) causing environment configuration to be overwritten by some other configuration methods.
+
 ## 0.1.2
 - Fix bug [#28](https://github.com/WeTransfer/ghost_adapter/issues/28) that resulted in add_index and remove_index calls to not run through `gh-ost`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ghost_adapter (0.1.2)
+    ghost_adapter (0.1.3)
       activerecord (>= 5)
       mysql2 (>= 0.4.0, < 0.6.0)
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,8 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
-
 require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
+RSpec::Core::RakeTask.new(:spec)
 
 task default: %i[spec rubocop]

--- a/lib/ghost_adapter/env_parser.rb
+++ b/lib/ghost_adapter/env_parser.rb
@@ -7,6 +7,9 @@ module GhostAdapter
         next unless ghost_key?(key)
 
         config_key = convert_env_key(key)
+
+        next unless GhostAdapter::CONFIG_KEYS.include?(config_key)
+
         config_value = convert_env_value(value)
 
         [config_key, config_value]
@@ -20,7 +23,7 @@ module GhostAdapter
     end
 
     def convert_env_key(key)
-      key.gsub('GHOST_', '').downcase
+      key.gsub('GHOST_', '').downcase.to_sym
     end
 
     def convert_env_value(value)

--- a/lib/ghost_adapter/version.rb
+++ b/lib/ghost_adapter/version.rb
@@ -1,3 +1,3 @@
 module GhostAdapter
-  VERSION = '0.1.2'.freeze
+  VERSION = '0.1.3'.freeze
 end

--- a/spec/active_record/connection_adapters/mysql2_ghost_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/mysql2_ghost_adapter_spec.rb
@@ -3,7 +3,7 @@ require 'active_record/connection_adapters/abstract/connection_pool'
 
 RSpec.describe ActiveRecord::ConnectionAdapters::Mysql2GhostAdapter do
   let(:logger) { double(:logger, puts: true) }
-  let(:mysql_client) { Mysql2::Client.new }
+  let(:mysql_client) { double('Mysql2::Client', query_options: {}, query: nil) }
 
   subject { described_class.new(mysql_client, logger, {}, {}) }
 

--- a/spec/ghost_adapter/config_spec.rb
+++ b/spec/ghost_adapter/config_spec.rb
@@ -15,6 +15,22 @@ RSpec.describe GhostAdapter::Config do
     end
   end
 
+  describe '#with_env' do
+    before do
+      allow_any_instance_of(GhostAdapter::EnvParser).to receive(:config).and_return({ tungsten: true })
+    end
+
+    it 'overwrites config values with ENV values' do
+      config = described_class.new(tungsten: false)
+      expect(config.with_env[:tungsten]).to be true
+    end
+
+    it 'does not mutate self' do
+      config = described_class.new(tungsten: false)
+      expect(config.tungsten).to be false
+    end
+  end
+
   describe '#as_args' do
     it 'skips false values' do
       options = { verbose: false }

--- a/spec/ghost_adapter/env_parser_spec.rb
+++ b/spec/ghost_adapter/env_parser_spec.rb
@@ -9,73 +9,79 @@ RSpec.describe GhostAdapter::EnvParser do
 
   context 'string values' do
     it 'reads string values and does no conversion' do
-      env = { 'GHOST_KEY' => 'test' }
+      env = { 'GHOST_DEBUG' => 'test' }
       config = described_class.new(env).config
-      expect(config['key']).to eq 'test'
+      expect(config[:debug]).to eq 'test'
     end
   end
 
   context 'converting number values' do
     it 'converts integer values' do
-      env = { 'GHOST_KEY' => '123' }
+      env = { 'GHOST_DEBUG' => '123' }
       config = described_class.new(env).config
-      expect(config['key']).to eq 123
+      expect(config[:debug]).to eq 123
     end
 
     it 'converts float values' do
-      env = { 'GHOST_KEY' => '1.23' }
+      env = { 'GHOST_DEBUG' => '1.23' }
       config = described_class.new(env).config
-      expect(config['key']).to eq 1.23
+      expect(config[:debug]).to eq 1.23
     end
   end
 
   context 'converting boolean values' do
     it 'converts "y" to true' do
-      env = { 'GHOST_KEY' => 'y' }
+      env = { 'GHOST_DEBUG' => 'y' }
       config = described_class.new(env).config
-      expect(config['key']).to be true
+      expect(config[:debug]).to be true
     end
 
     it 'converts "yes" to true' do
-      env = { 'GHOST_KEY' => 'yes' }
+      env = { 'GHOST_DEBUG' => 'yes' }
       config = described_class.new(env).config
-      expect(config['key']).to be true
+      expect(config[:debug]).to be true
     end
 
     it 'converts "t" to true' do
-      env = { 'GHOST_KEY' => 't' }
+      env = { 'GHOST_DEBUG' => 't' }
       config = described_class.new(env).config
-      expect(config['key']).to be true
+      expect(config[:debug]).to be true
     end
 
     it 'converts "true" to true' do
-      env = { 'GHOST_KEY' => 'true' }
+      env = { 'GHOST_DEBUG' => 'true' }
       config = described_class.new(env).config
-      expect(config['key']).to be true
+      expect(config[:debug]).to be true
     end
 
     it 'converts "n" to false' do
-      env = { 'GHOST_KEY' => 'n' }
+      env = { 'GHOST_DEBUG' => 'n' }
       config = described_class.new(env).config
-      expect(config['key']).to be false
+      expect(config[:debug]).to be false
     end
 
     it 'converts "no" to false' do
-      env = { 'GHOST_KEY' => 'no' }
+      env = { 'GHOST_DEBUG' => 'no' }
       config = described_class.new(env).config
-      expect(config['key']).to be false
+      expect(config[:debug]).to be false
     end
 
     it 'converts "f" to false' do
-      env = { 'GHOST_KEY' => 'f' }
+      env = { 'GHOST_DEBUG' => 'f' }
       config = described_class.new(env).config
-      expect(config['key']).to be false
+      expect(config[:debug]).to be false
     end
 
     it 'converts "false" to false' do
-      env = { 'GHOST_KEY' => 'false' }
+      env = { 'GHOST_DEBUG' => 'false' }
       config = described_class.new(env).config
-      expect(config['key']).to be false
+      expect(config[:debug]).to be false
+    end
+
+    it 'is case insensitive' do
+      env = { 'GHOST_DEBUG' => 'NO' }
+      config = described_class.new(env).config
+      expect(config[:debug]).to be false
     end
   end
 end


### PR DESCRIPTION
## Description

ENV was overwritten when configuration happened via block.

Fixes #26 

This also fixes the issue where setting _any_ other environment variable that starts with `GHOST_` would raise an error

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added a new `#with_env` method and tested that.

## Checklist:

- [x] My code follows the style guidelines set by rubocop
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
