### PR TITLE
Add add_index and remove_index methods to adapter that force ALTER TABLE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# CHANGELOG
+
+## 0.1.2
+- Fix bug [#28](https://github.com/WeTransfer/ghost_adapter/issues/28) that resulted in add_index and remove_index calls to not run through `gh-ost`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ghost_adapter (0.1.1)
+    ghost_adapter (0.1.2)
       activerecord (>= 5)
 
 GEM

--- a/lib/active_record/connection_adapters/mysql2_ghost_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2_ghost_adapter.rb
@@ -56,6 +56,16 @@ module ActiveRecord
         end
       end
 
+      def add_index(table_name, column_name, options = {})
+        index_name, index_type, index_columns, index_options = add_index_options(table_name, column_name, options)
+        execute "ALTER TABLE #{quote_table_name(table_name)} ADD #{index_type} INDEX #{quote_column_name(index_name)} (#{index_columns})#{index_options}" # rubocop:disable Layout/LineLength
+      end
+
+      def remove_index(table_name, options = {})
+        index_name = index_name_for_remove(table_name, options)
+        execute "ALTER TABLE #{quote_table_name(table_name)} DROP INDEX #{quote_column_name(index_name)}"
+      end
+
       private
 
       attr_reader :database, :dry_run

--- a/lib/ghost_adapter/version.rb
+++ b/lib/ghost_adapter/version.rb
@@ -1,3 +1,3 @@
 module GhostAdapter
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.1.2'.freeze
 end


### PR DESCRIPTION
## Description

The methods defined in ActiveRecord ([here](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb#L91-L106)) generate `CREATE INDEX` SQL.  This will not run through `gh-ost`.  We should instead have these methods generate `ALTER TABLE ADD INDEX`.

Fixes #28 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Ran a migration for a rails application that uses `add_index`.  It did run through `gh-ost`

## Checklist:

- [x] My code follows the style guidelines set by rubocop
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
  - Not adding these now as it basically requires rspec and I sort of _need_ to get this out ASAP.  Will submit additional PR this evening converting minitest suite to rspec
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
