### PR TITLE
Fix missing require of 'ghost_adapter' in the connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.2.1
+- Fix bug caused by missing `require 'ghost_adapter'` for non-rails apps ([#34](https://github.com/WeTransfer/ghost_adapter/pull/34))
+
 ## 0.2.0
 
 - Add templating to configuration values.  See [the docs](./docs/config/templating.md) for more info on how to use this feature.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ghost_adapter (0.2.0)
+    ghost_adapter (0.2.1)
       activerecord (>= 5)
       mysql2 (>= 0.4.0, < 0.6.0)
 
@@ -24,7 +24,7 @@ GEM
     byebug (11.1.3)
     concurrent-ruby (1.1.8)
     diff-lcs (1.4.4)
-    i18n (1.8.9)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     minitest (5.14.4)
     mysql2 (0.5.3)
@@ -79,4 +79,4 @@ DEPENDENCIES
   rubocop (~> 1)
 
 BUNDLED WITH
-   2.2.6
+   2.2.7

--- a/lib/active_record/connection_adapters/mysql2_ghost_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2_ghost_adapter.rb
@@ -1,4 +1,5 @@
 require 'active_record/connection_adapters/mysql2_adapter'
+require 'ghost_adapter'
 require 'ghost_adapter/migrator'
 require 'ghost_adapter/version_checker'
 require 'mysql2'

--- a/lib/ghost_adapter/version.rb
+++ b/lib/ghost_adapter/version.rb
@@ -1,3 +1,3 @@
 module GhostAdapter
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.2.1'.freeze
 end


### PR DESCRIPTION
## Description

This fixes a bug that occurs because files are not auto-loaded in non-rails apps.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Created a simple Sinatra application using this version

## Checklist:

- [x] My code follows the style guidelines set by rubocop
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
