### PR TITLE
Add azure config option found in gh-ost version 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # CHANGELOG
 
+## 0.2.2
+
+- Bump rexml from 3.2.4 to 3.2.5 (security fix) ([#35](https://github.com/WeTransfer/ghost_adapter/pull/35))
+- Add azure configuration option now available with gh-ost v1.1.1 ([#36](https://github.com/WeTransfer/ghost_adapter/pull/36))
+
 ## 0.2.1
+
 - Fix bug caused by missing `require 'ghost_adapter'` for non-rails apps ([#34](https://github.com/WeTransfer/ghost_adapter/pull/34))
 
 ## 0.2.0
 
-- Add templating to configuration values.  See [the docs](./docs/config/templating.md) for more info on how to use this feature.
+- Add templating to configuration values. See [the docs](./docs/config/templating.md) for more info on how to use this feature.
 
 ## 0.1.4
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,19 @@
 PATH
   remote: .
   specs:
-    ghost_adapter (0.2.1)
+    ghost_adapter (0.2.2)
       activerecord (>= 5)
       mysql2 (>= 0.4.0, < 0.6.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.3.1)
-      activesupport (= 6.1.3.1)
-    activerecord (6.1.3.1)
-      activemodel (= 6.1.3.1)
-      activesupport (= 6.1.3.1)
-    activesupport (6.1.3.1)
+    activemodel (6.1.3.2)
+      activesupport (= 6.1.3.2)
+    activerecord (6.1.3.2)
+      activemodel (= 6.1.3.2)
+      activesupport (= 6.1.3.2)
+    activesupport (6.1.3.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 [![Gem](https://img.shields.io/gem/v/ghost_adapter)](https://rubygems.org/gems/ghost_adapter)
 ![GitHub Actions Workflow](https://github.com/WeTransfer/ghost_adapter/actions/workflows/tests.yml/badge.svg)
 [![Hippocratic License](https://img.shields.io/badge/license-Hippocratic-green)](https://github.com/WeTransfer/ghost_adapter/blob/main/LICENSE.md)
-[![gh-ost version](https://img.shields.io/badge/gh--ost%20version-1.1.0-blue)](https://github.com/github/gh-ost/releases/latest)
+[![gh-ost version](https://img.shields.io/badge/gh--ost%20version-1.1.1-blue)](https://github.com/github/gh-ost/releases/latest)
 
 A tiny, _very configurable_ ActiveRecord adapter built for running [gh-ost](https://github.com/github/gh-ost) migrations. When not running migrations, it'll stay the heck out of the way.
 
 ## Installation
 
-First, you'll need to install `gh-ost`. You can find the latest release [here](https://github.com/github/gh-ost/releases/latest). You can check the allowed version range in [the version checker](./lib/ghost_adapter/version_checker.rb#L13) (current range: [>= 1.1, < 2]). Once you've got that installed, install the gem!
+First, you'll need to install `gh-ost`. You can find the latest release [here](https://github.com/github/gh-ost/releases/latest). You can check the allowed version range in [the version checker](./lib/ghost_adapter/version_checker.rb#L13) (current range: [>= 1.1.0, < 2]). Once you've got that installed, install the gem!
 
 Add this line to your application's Gemfile:
 

--- a/lib/ghost_adapter/config.rb
+++ b/lib/ghost_adapter/config.rb
@@ -8,6 +8,7 @@ module GhostAdapter
                    approve_renamed_columns
                    assume_master_host
                    assume_rbr
+                   azure
                    check_flag
                    chunk_size
                    concurrent_rowcount

--- a/lib/ghost_adapter/version.rb
+++ b/lib/ghost_adapter/version.rb
@@ -1,3 +1,3 @@
 module GhostAdapter
-  VERSION = '0.2.1'.freeze
+  VERSION = '0.2.2'.freeze
 end


### PR DESCRIPTION
## Description

A new configuration option is available in ghost 1.1.1 ([release notes](https://github.com/github/gh-ost/releases/tag/v1.1.1))

## Type of change


- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the style guidelines set by rubocop
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
