### PR TITLE
Remove usage of OpenStruct

### DIFF
--- a/ghost_adapter.gemspec
+++ b/ghost_adapter.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage
+  spec.metadata['rubygems_mfa_required'] = 'true'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/spec/ghost_adapter/version_checker_spec.rb
+++ b/spec/ghost_adapter/version_checker_spec.rb
@@ -3,8 +3,8 @@ require 'ghost_adapter/version_checker'
 require 'open3'
 
 RSpec.describe GhostAdapter::VersionChecker do
-  let(:failed_process) { OpenStruct.new('success?' => false) }
-  let(:success_process) { OpenStruct.new('success?' => true) }
+  let(:failed_process) { instance_double('Process::Status', success?: false) }
+  let(:success_process) { instance_double('Process::Status', success?: true) }
 
   it 'raises an error if gh-ost is not installed' do
     expect(Open3).to receive(:capture2).and_return(['', failed_process])


### PR DESCRIPTION
## Description

Daily tests are currently failing (must've been a new rubocop version released?).  We should use an `instance_double` instead of an `OpenStruct` for mocking the responses anyways.


## How Has This Been Tested?

It's part of the unit test suite.

## Checklist:

- [x] My code follows the style guidelines set by rubocop
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [s] I have checked my code and corrected any misspellings
