### PR TITLE
Run tests against ruby 3.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
           - "2.6"
           - "2.7"
           - "3.0"
+          - "3.1"
         gemfile:
           - "gemfiles/activerecord-5.0.Gemfile"
           - "gemfiles/activerecord-5.1.Gemfile"
@@ -34,6 +35,14 @@ jobs:
           - ruby-version: "3.0"
             gemfile: "gemfiles/activerecord-5.2.Gemfile"
           - ruby-version: "3.0"
+            gemfile: "gemfiles/activerecord-6.0.Gemfile"
+          - ruby-version: "3.1"
+            gemfile: "gemfiles/activerecord-5.0.Gemfile"
+          - ruby-version: "3.1"
+            gemfile: "gemfiles/activerecord-5.1.Gemfile"
+          - ruby-version: "3.1"
+            gemfile: "gemfiles/activerecord-5.2.Gemfile"
+          - ruby-version: "3.1"
             gemfile: "gemfiles/activerecord-6.0.Gemfile"
           # Ruby >= 2.7 is required for ActiveRecord >= 7
           - ruby-version: "2.5"


### PR DESCRIPTION
## Description

Since Ruby 3.1 was released, we should start testing against it.

## How Has This Been Tested?

It is testing
