### PR TITLE
Allow backticks in gh-ost query

### DIFF
--- a/lib/active_record/connection_adapters/mysql2_ghost_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2_ghost_adapter.rb
@@ -103,7 +103,7 @@ module ActiveRecord
       attr_reader :database, :dry_run
 
       ALTER_TABLE_PATTERN = /\AALTER\s+TABLE\W*(?<table_name>\w+)\W*(?<query>.*)$/i.freeze
-      QUERY_ALLOWABLE_CHARS = /[^0-9a-z_\s():'"{},]/i.freeze
+      QUERY_ALLOWABLE_CHARS = /[^0-9a-z_\s():'"{},`]/i.freeze
       CREATE_TABLE_PATTERN = /\Acreate\stable/i.freeze
       DROP_TABLE_PATTERN = /\Acreate\stable/i.freeze
       INSERT_SCHEMA_MIGRATION_PATTERN = /\Ainsert\sinto\s`schema_migrations`/i.freeze

--- a/lib/ghost_adapter/version.rb
+++ b/lib/ghost_adapter/version.rb
@@ -1,3 +1,3 @@
 module GhostAdapter
-  VERSION = '0.4.1'.freeze
+  VERSION = '0.4.2'.freeze
 end

--- a/spec/active_record/connection_adapters/mysql2_ghost_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/mysql2_ghost_adapter_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe ActiveRecord::ConnectionAdapters::Mysql2GhostAdapter do
           'ADD index_type INDEX `baz_index_name` (`baz_id`);;;'
 
         sanatized_sql =
-          'ADD index_type INDEX bar_index_name (bar_id), '\
-          'ADD index_type INDEX baz_index_name (baz_id)'
+          'ADD index_type INDEX `bar_index_name` (`bar_id`), '\
+          'ADD index_type INDEX `baz_index_name` (`baz_id`)'
 
         expect(GhostAdapter::Migrator).to receive(:execute)
           .with(table.to_s, sanatized_sql, any_args)


### PR DESCRIPTION
## Description

Backticks are needed if any columns, tables, etc have names that are [MySQL reserved keywords](https://dev.mysql.com/doc/refman/5.7/en/keywords.html).

Fixes #70 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests have been updated and I've run a migration locally with a column named `interval`

## Checklist:

- [x] My code follows the style guidelines set by rubocop
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
