### PR TITLE
Add support for gh-ost v1.1.6 command line flags and drop deprecated flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## 0.7.0
+- Chore: add short docs for how to release the gem ([#76](https://github.com/WeTransfer/ghost_adapter/pull/76))
+- Update activerecord requirement from >= 5, <= 7.2 to >= 5, <= 8.1 ([#78](https://github.com/WeTransfer/ghost_adapter/pull/78))
+- Add support for gh-ost v1.1.6 command line flags and drop deprecated flag ([#79](https://github.com/WeTransfer/ghost_adapter/pull/79))
+
+## 0.6.0
+- Update activerecord requirement from >= 5, <= 7.1 to >= 5, <= 7.2 ([#75](https://github.com/WeTransfer/ghost_adapter/pull/75))
+
+## 0.5.0
+- Add support for optional async argument ([#72](https://github.com/WeTransfer/ghost_adapter/pull/72))
+
+## 0.4.2
+- Allow backticks in gh-ost query ([#71](https://github.com/WeTransfer/ghost_adapter/pull/71))
+
 ## 0.4.1
 - Add support for ActiveRecord 7.0.1 ([#69](https://github.com/WeTransfer/ghost_adapter/pull/69))
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,0 @@
-# https://help.github.com/en/articles/about-code-owners
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence, they
-# will be requested for review when someone opens a PR.
-*       @acroos

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at austin.roos@wetransfer.com. All
+reported by contacting the project team at engineering@wetransfer.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 - @acroos (Austin C. Roos, austin.roos@wetransfer.com)
 - @grdw (Gerard Westerhof, gerard@wetransfer.com)
 - @epintos (Esteban Pintos, esteban.pintos@wetransfer.com)
+- @nickdowse (Nick Dowse, nick.dowse@wetransfer.com)

--- a/lib/ghost_adapter/config.rb
+++ b/lib/ghost_adapter/config.rb
@@ -5,10 +5,13 @@ module GhostAdapter
                    allow_master_master
                    allow_nullable_unique_key
                    allow_on_master
+                   allow_zero_in_date
                    approve_renamed_columns
                    assume_master_host
                    assume_rbr
+                   attempt_instant_ddl
                    azure
+                   binlogsyncer_max_reconnect_attempts
                    check_flag
                    chunk_size
                    concurrent_rowcount
@@ -54,7 +57,6 @@ module GhostAdapter
                    postpone_cut_over_flag_file
                    quiet
                    replica_server_id
-                   replication_lag_query
                    serve_socket_file
                    serve_tcp_port
                    skip_foreign_key_checks
@@ -73,6 +75,8 @@ module GhostAdapter
                    throttle_control_replicas
                    throttle_flag_file
                    throttle_http
+                   throttle_http_interval_millis
+                   throttle_http_timeout_millis
                    throttle_query
                    timestamp_old_table
                    tungsten

--- a/lib/ghost_adapter/version.rb
+++ b/lib/ghost_adapter/version.rb
@@ -1,3 +1,3 @@
 module GhostAdapter
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.7.0'.freeze
 end


### PR DESCRIPTION
## Description

Add support for new command line flags in gh-ost [v1.1.5](https://github.com/github/gh-ost/releases/tag/v1.1.5) and [v1.1.6](https://github.com/github/gh-ost/releases/tag/v1.1.6):
* `--throttle-http-interval-millis`
* `--throttle-http-timeout-millis`
* `--attempt-instant-ddl`
* `--allow-zero-in-date`
* `--binlogsyncer-max-reconnect-attempts`

**Breaking Change** we're also removing support for `replication-lag-query` flag ahead of it's deprecation in `gh-ost` v1.1.7. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines set by rubocop
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
