### PR TITLE
fix: pin GitHub Actions to SHA for supply chain security

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,9 +41,9 @@ jobs:
           - ruby-version: "2.6"
             gemfile: "gemfiles/activerecord-7.0.Gemfile"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
       - name: Install gems


### PR DESCRIPTION
## Summary

Pin all GitHub Actions to full commit SHAs for supply chain security.

Actions referenced by tag or branch have been resolved to their commit SHA, with the original ref preserved as an inline comment. Where a sub-action had unpinned transitive dependencies, the action was upgraded to the closest newer version where all sub-actions are fully pinned.
