### PR TITLE
Fix scheduled CI: RuboCop drift, latent test failures, and dependency rot

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,18 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
       - name: Install gems
         run: bundle install --gemfile ${{ matrix.gemfile }}
-      - name: Run rubocop
-        run: bundle exec rake rubocop
       - name: Run tests
         run: bundle exec --gemfile ${{ matrix.gemfile }} rspec
+
+  rubocop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1
+        with:
+          ruby-version: "3.3"
+      - name: Install gems
+        run: bundle install --gemfile gemfiles/rubocop.gemfile
+      - name: Run rubocop
+        run: bundle exec --gemfile gemfiles/rubocop.gemfile rubocop

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby-version:
           - "2.5"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron:  '45 */6 * * *'
 
+# The workflow only needs to read the repository to test and lint it.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,10 @@ Style/Documentation:
 Style/RescueModifier:
   Enabled: false
 
+# Development dependencies are intentionally declared in the gemspec.
+Gemspec/DevelopmentDependencies:
+  Enabled: false
+
 Layout/LineLength:
   Exclude:
     - spec/**/*_spec.rb
@@ -28,7 +32,7 @@ Metrics/MethodLength:
     - 'array'
     - 'hash'
     - 'heredoc'
-  IgnoredMethods:
+  AllowedMethods:
     - build_ghost_command
     - mysql2_ghost_connection
 
@@ -41,12 +45,12 @@ Metrics/ModuleLength:
     - lib/ghost_adapter/config.rb
 
 Metrics/AbcSize:
-  IgnoredMethods:
+  AllowedMethods:
     - build_ghost_command
     - mysql2_ghost_connection
 
 Metrics/PerceivedComplexity:
-  IgnoredMethods:
+  AllowedMethods:
     - mysql2_ghost_connection
 
 AllCops:

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,14 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
-require 'rubocop/rake_task'
 
-RuboCop::RakeTask.new
 RSpec::Core::RakeTask.new(:spec)
 
-task default: %i[spec rubocop]
+# RuboCop lives in a separate bundle (gemfiles/rubocop.gemfile) so it is not
+# required for the test matrix. Only wire up the task when it is available.
+begin
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new
+  task default: %i[spec rubocop]
+rescue LoadError
+  task default: %i[spec]
+end

--- a/gemfiles/activerecord-6.0.Gemfile
+++ b/gemfiles/activerecord-6.0.Gemfile
@@ -2,4 +2,10 @@ source 'http://rubygems.org'
 
 gem 'activerecord', '~> 6.0.0'
 
+# concurrent-ruby >= 1.3.5 dropped its transitive `require 'logger'`, which
+# breaks ActiveSupport < 7.1 (uninitialized constant
+# ActiveSupport::LoggerThreadSafeLevel::Logger). This EOL ActiveRecord never
+# received the upstream fix, so pin below that release.
+gem 'concurrent-ruby', '< 1.3.5'
+
 gemspec path: '../'

--- a/gemfiles/activerecord-6.1.Gemfile
+++ b/gemfiles/activerecord-6.1.Gemfile
@@ -2,4 +2,10 @@ source 'http://rubygems.org'
 
 gem 'activerecord', '~> 6.1.0'
 
+# concurrent-ruby >= 1.3.5 dropped its transitive `require 'logger'`, which
+# breaks ActiveSupport < 7.1 (uninitialized constant
+# ActiveSupport::LoggerThreadSafeLevel::Logger). This EOL ActiveRecord never
+# received the upstream fix, so pin below that release.
+gem 'concurrent-ruby', '< 1.3.5'
+
 gemspec path: '../'

--- a/gemfiles/rubocop.gemfile
+++ b/gemfiles/rubocop.gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+# Dedicated bundle for the lint job. It deliberately does NOT pull in the
+# gemspec (and therefore activerecord/mysql2), so linting needs no native
+# builds and is independent of the test matrix's Ruby/ActiveRecord versions.
+# Pinned to a single minor so new RuboCop releases land as deliberate upgrades
+# instead of breaking scheduled runs.
+gem 'rubocop', '~> 1.87.0'

--- a/ghost_adapter.gemspec
+++ b/ghost_adapter.gemspec
@@ -31,5 +31,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'byebug', '~> 11.1'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3'
-  spec.add_development_dependency 'rubocop', '~> 1'
+  # RuboCop is intentionally not listed here: it is version-sensitive to the
+  # Ruby being used, which conflicts with the Ruby 2.5-3.0 test matrix. It runs
+  # in a dedicated lint job on a single modern Ruby (see gemfiles/rubocop.gemfile
+  # and .github/workflows/tests.yml).
 end

--- a/lib/active_record/connection_adapters/mysql2_ghost_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2_ghost_adapter.rb
@@ -52,7 +52,7 @@ module ActiveRecord
           if (table, query = parse_sql(sql))
             GhostAdapter::Migrator.execute(table, query, database, dry_run)
           else
-            super(sql, name, async: async)
+            super
           end
         end
       else
@@ -63,7 +63,7 @@ module ActiveRecord
           if (table, query = parse_sql(sql))
             GhostAdapter::Migrator.execute(table, query, database, dry_run)
           else
-            super(sql, name)
+            super
           end
         end
       end
@@ -121,6 +121,8 @@ module ActiveRecord
       DROP_TABLE_PATTERN = /\Acreate\stable/i.freeze
       INSERT_SCHEMA_MIGRATION_PATTERN = /\Ainsert\sinto\s`schema_migrations`/i.freeze
       DROP_SCHEMA_MIGRATION_PATTERN = /\Adelete\sfrom\s`schema_migrations`/i.freeze
+      private_constant :ALTER_TABLE_PATTERN, :QUERY_ALLOWABLE_CHARS, :CREATE_TABLE_PATTERN,
+                       :DROP_TABLE_PATTERN, :INSERT_SCHEMA_MIGRATION_PATTERN, :DROP_SCHEMA_MIGRATION_PATTERN
 
       def parse_sql(sql)
         capture = sql.match(ALTER_TABLE_PATTERN)

--- a/lib/ghost_adapter/command.rb
+++ b/lib/ghost_adapter/command.rb
@@ -22,6 +22,7 @@ module GhostAdapter
     private
 
     EXECUTABLE = 'gh-ost'.freeze
+    private_constant :EXECUTABLE
 
     attr_reader :alter, :database, :table, :dry_run
 

--- a/spec/active_record/connection_adapters/mysql2_ghost_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/mysql2_ghost_adapter_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe ActiveRecord::ConnectionAdapters::Mysql2GhostAdapter do
 
   before do
     allow(mysql_client).to receive(:server_info).and_return({ id: 50_732, version: '5.7.32-log' })
+    # Recent ActiveRecord patches verify the raw connection's liveness while
+    # building statements. The real Mysql2::Client answers the whole
+    # ping/closed?/close protocol, so the double must too.
+    allow(mysql_client).to receive(:ping).and_return(true)
+    allow(mysql_client).to receive(:closed?).and_return(false)
+    allow(mysql_client).to receive(:close)
     if Gem.loaded_specs['activerecord'].version < Gem::Version.new('6.1')
       allow(mysql_client).to receive(:escape).with(table.to_s).and_return(table.to_s)
       allow(mysql_client).to receive(:more_results?)


### PR DESCRIPTION
## Why

The [scheduled `Tests` run](https://github.com/WeTransfer/ghost_adapter/actions/runs/27572513658) failed at **Run rubocop** with no code change. Fixing that surfaced further pre-existing failures that had been masked by the rubocop step + `fail-fast`. This PR gets the **entire matrix green** (18 Ruby × ActiveRecord combos + a lint job).

Root cause throughout: a gem testing EOL Ruby (2.5–3.0) × EOL Rails (5.0–7.0) against the latest transitive dependencies, with no lockfile, on a 6-hour schedule — so dependency drift accumulates silently until something breaks.

## Changes

**1. RuboCop offenses (the reported failure).** Bundler resolved the unpinned `rubocop ~> 1` to 1.87.0 on Ruby 2.7/3.0, which (with `NewCops: enable`) introduced new cops and renamed a config key.
- `Style/SuperArguments` → bare `super` (forwards identical args; behavior-neutral)
- `Lint/UselessConstantScoping` → `private_constant` (the `private` modifier is a no-op for constants)
- `Gemspec/DevelopmentDependencies` → disabled (dev deps intentionally in the gemspec)
- `IgnoredMethods` → `AllowedMethods` (the old key had silently stopped applying the Metrics exclusions)

**2. RuboCop runs in a dedicated lint job, not the test matrix.** A single pinned rubocop can't satisfy a Ruby 2.5–3.0 matrix (1.87 needs ≥ 2.7; the version bundler picks for 2.5 rejects newer config keys as a *fatal* error). Linting now runs once on a modern Ruby via `gemfiles/rubocop.gemfile` (rubocop only — no gemspec, so no mysql2 native build), pinned so future releases are deliberate upgrades. This permanently defuses the scheduled rubocop drift.

**3. Latent test failure — `Mysql2::Client` double.** Current ActiveRecord patches probe the raw connection's liveness (`ping`/`closed?`/`close`) while building statements; the real client answers these, so the test double now does too.

**4. Dependency rot — `concurrent-ruby` 1.3.5.** It dropped its transitive `require 'logger'`, breaking ActiveSupport < 7.1 at load (`uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger`). AR 7.0 got the upstream fix; the EOL 6.0/6.1 lines did not, so those gemfiles pin `concurrent-ruby < 1.3.5`.

**5. `fail-fast: false`** on the matrix so independent compat failures surface together instead of one-per-run.

## Verification

All 19 jobs green (18 matrix combos + lint). RuboCop (1.87.0) locally: 24 files, no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)